### PR TITLE
Align site with resume: harness/sandbox framing, fix cache numbers, d…

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -31,10 +31,10 @@
     <p class="hero-sub">
       Platform AI Architect and Principal Engineer with <span class="highlight">13+ years</span>
       delivering production AI systems at scale. Built
-      <a href="{base}/projects/devgpt" class="gold-link">DevGPT</a> —
-      a state-of-the-art autonomous coding agent platform serving
-      <span class="highlight">6,500+ engineers</span> at J.P. Morgan Chase,
-      with a custom agentic loop, layered memory system, and strict brain/hands execution isolation.
+      <a href="{base}/projects/devgpt" class="gold-link">DevGPT</a>, a coding agent harness serving
+      <span class="highlight">6,500+ engineers</span> at J.P. Morgan Chase, architected as a clean
+      separation between the reasoning harness ("brain") and an isolated remote sandbox controller
+      ("hands") for secure, multi-tenant agentic code execution.
       Engineered prompt caching to <span class="highlight">90%+ hit rates</span> and a
       distributed telemetry pipeline handling <span class="highlight">50K events/min</span>.
     </p>

--- a/src/lib/components/Timeline.svelte
+++ b/src/lib/components/Timeline.svelte
@@ -9,12 +9,15 @@
       org: 'J.P. Morgan Chase',
       tag: 'current',
       highlights: [
-        'Architect of AI4Tech, a dedicated platform org with its own SEAL, AWS accounts, and cost center',
-        'DevGPT powers Technology Lifecycle Management (TLM) — firm-wide agentic software maintenance across Terraform, Python, Java, and Golang codebases',
-        'Supervisor agent reviews patches on a dedicated maintenance branch and routes changes to owning teams for merge',
-        'Anthropic SRT + bubblewrap sandbox (early 2026)',
+        'Lead architect for DevGPT\'s core agentic systems: the coding harness (reasoning, tool use, memory) and a separate remote sandbox controller for isolated code execution',
+        'Coding agent harness — custom agentic loop, tool-calling, and multi-step execution comparable in scope to Claude Code, fully decoupled from execution',
+        'Remote sandbox controller — pool-managed, session-aware Kubernetes pods on EKS with MCP Bridge and SOCKS5/socat network isolation; the harness never holds credentials or network access directly',
+        'DevGPT Cloud — the collaboration layer: co-ideate with an agent alongside teammates, push/pull sessions, observe live sandbox execution, browse a team agent marketplace',
+        'DevGPT powers Technology Lifecycle Management (TLM) — firm-wide agentic maintenance across Java codebases today, expanding to Python, Golang, TypeScript, and Terraform',
+        'Sole AI4Tech engineer on the AWM AI Center of Excellence, defining agentic development standards across the firm',
+        'Designing AWM Agentic Training (in dev) — a Trailhead-style platform using AI as a Socratic brainstorming partner and grader',
         'Temporal-backed durable agent orchestration',
-        'Multi-layer memory system (Org / Team / User / Session)',
+        'Four-layer memory system (Org / Team / User / Session) — in development',
         '2-week AWS org migration with 30-minute planned outage — zero data loss',
       ]
     },
@@ -25,12 +28,13 @@
       tag: 'jpmc',
       highlights: [
         'Built DevGPT from the ground up within AWM\'s Architecture & Investment Technology team',
-        '~90% prompt cache hit rates on Anthropic models; 20M peak cache reads/min against a 30M TPM budget',
-        'Hybrid model routing — Anthropic via AWS Bedrock, OpenAI via Azure OpenAI',
+        '~90% prompt cache hit rates on Anthropic models; 32M peak cache reads/min against a 30M TPM budget',
+        'Two independent, mission-critical LLM provider services — Anthropic via AWS Bedrock, OpenAI via Azure OpenAI — no shared prompt router; provider selection is a deliberate, user-facing decision',
+        'Custom telemetry gateway: producer → SQS → consumer → staging → processors, feeding a federated service (Aurora writes, real-time attribution) and a separate analytics service (read replica, reporting) — ~50K events/min',
         'Kubernetes API gateway on EKS using Cilium with per-LOB auth, rate limiting, load shedding',
         '65% AWS cost reduction — Karpenter/EKS node group migration + smart prompt engineering & context caching',
         'Knowledge Graphs & Event-Driven News Analytics Platform — entity resolution at ~900ms/article',
-        'Sm@rt RFP — weeks to minutes for client proposal generation (patent pending)',
+        'Sm@rt RFP — weeks to minutes for client proposal generation',
       ]
     },
     {

--- a/src/routes/projects/devgpt/+page.svelte
+++ b/src/routes/projects/devgpt/+page.svelte
@@ -5,7 +5,7 @@
     { layer: 'IDE Layer',           items: ['VS Code', 'IntelliJ', 'CLI / Headless'],  color: '#c9a84c' },
     { layer: 'Agent Harness',       items: ['devgpt-cli (TypeScript)', 'ACP Protocol', 'Headless / Cloud modes'],       color: '#8b7ec8' },
     { layer: 'Orchestration',       items: ['Temporal Workflows', 'Pause / Resume / Fork', 'Durable Execution'],            color: '#7c9e87' },
-    { layer: 'Execution',           items: ['Kubernetes EKS', 'KEDA Autoscaling', 'Anthropic SRT + bubblewrap'],            color: '#d4856a' },
+    { layer: 'Execution',           items: ['Kubernetes EKS', 'KEDA Autoscaling', 'Remote Sandbox Controller + bubblewrap'],            color: '#d4856a' },
     { layer: 'Context Assembly',    items: ['EFS Bare Git Clones', 'Per-Task Worktrees', 'Context Assembler'],              color: '#6a9fd4' },
     { layer: 'Memory',              items: ['OpenSearch (Cohere Embed v4)', 'RDS Postgres', 'Dream Cycle Consolidation'],   color: '#a8c47c' },
     { layer: 'Streaming',           items: ['WebSockets', 'Redis Streams', 'NATS', 'Go Cloud API', 'SSE to IDE'],           color: '#c47ca8' },
@@ -96,8 +96,8 @@
           <p>Memory Service holds per-user structured operational facts. Brain holds platform-wide institutional narrative. Both queried in parallel and merged at agent boot.</p>
         </div>
         <div class="principle">
-          <div class="principle-title mono">Warm Pods · SRT + Istio Ambient</div>
-          <p>Pre-warmed pod pools eliminate cold-start latency at dispatch. Anthropic SRT sandboxes sit ready behind Istio Ambient Mode — sidecar-free mTLS and L4 policy enforced at the node level, keeping the data plane out of the agent container entirely.</p>
+          <div class="principle-title mono">Warm Pods · Remote Sandbox Controller + Istio Ambient</div>
+          <p>Pre-warmed pod pools eliminate cold-start latency at dispatch. Remote sandbox controller pods sit ready behind Istio Ambient Mode — sidecar-free mTLS and L4 policy enforced at the node level, keeping the data plane out of the agent container entirely.</p>
         </div>
         <div class="principle">
           <div class="principle-title mono">Supervisor-Gated Maintenance</div>
@@ -112,10 +112,11 @@
       <div class="sandbox-card">
         <p>
           DevGPT powers TLM — a firm-wide JPMC initiative for automated software maintenance.
-          Agentic workflows perform dependency updates and patches across Terraform, Python, Java,
-          and Golang codebases on a dedicated maintenance branch. A supervisor agent reviews proposed
-          changes and routes them to the owning team for merge to release/master. TLM operates across
-          the full firm while the platform org remains AI4Tech-chartered within AWM.
+          Agentic workflows perform dependency updates and patches across Java codebases today
+          on a dedicated maintenance branch, expanding to Python, Golang, TypeScript, and Terraform.
+          A supervisor agent reviews proposed changes and routes them to the owning team for merge
+          to release/master. TLM operates across the full firm while the platform team remains
+          AWM-chartered.
         </p>
       </div>
     </section>
@@ -125,12 +126,12 @@
       <div class="section-label mono">Sandbox Runtime</div>
       <div class="sandbox-card">
         <div class="sandbox-header">
-          <span class="sandbox-badge mono">Anthropic SRT + bubblewrap</span>
+          <span class="sandbox-badge mono">Remote Sandbox Controller + bubblewrap</span>
           <span class="sandbox-status mono">● Production</span>
         </div>
         <p>
-          Agents execute untrusted code in sandboxed subprocesses using Anthropic's Sandbox Runtime,
-          which leverages bubblewrap for lightweight, kernel-level process isolation — no privileged containers,
+          Agents execute untrusted code in sandboxed subprocesses via a purpose-built remote sandbox
+          controller, which leverages bubblewrap for lightweight, kernel-level process isolation — no privileged containers,
           no separate runtime service. Leveraging Istio Integrated directly into the DevGPT plugin and CLI.
           Sub-2-second dispatch target with warm pod pool strategies via Karpenter NodePool and KEDA ScaledObject.
         </p>
@@ -142,9 +143,9 @@
       <div class="section-label mono">Infrastructure</div>
       <div class="sandbox-card">
         <p>
-          In 2025, DevGPT migrated from AWM's shared AWS org into a dedicated SEAL with its own
-          accounts and cost center under AI4Tech. The 2-week migration completed with a 30-minute
-          planned outage — no data loss, no user-facing failures.
+          In 2025, led a 2-week migration of DevGPT from AWM's shared AWS org into a new dedicated
+          account structure to support firm-wide scale — completed with a 30-minute
+          planned outage, zero data loss, no user-facing failures.
         </p>
       </div>
     </section>
@@ -156,12 +157,12 @@
         <a href="https://github.com/anthropic-experimental/sandbox-runtime" target="_blank" rel="noopener" class="ref-link mono">
           <span class="ref-icon">↗</span>
           <span>anthropic-experimental/sandbox-runtime</span>
-          <span class="ref-desc">Anthropic SRT — kernel-level sandbox for secure agent execution</span>
+          <span class="ref-desc">Remote Sandbox Controller — kernel-level isolation for secure agent execution</span>
         </a>
         <a href="https://github.com/containers/bubblewrap" target="_blank" rel="noopener" class="ref-link mono">
           <span class="ref-icon">↗</span>
           <span>containers/bubblewrap</span>
-          <span class="ref-desc">Bubblewrap — unprivileged process isolation underpinning SRT</span>
+          <span class="ref-desc">Bubblewrap — unprivileged process isolation underpinning the sandbox controller</span>
         </a>
         <a href="https://temporal.io/" target="_blank" rel="noopener" class="ref-link mono">
           <span class="ref-icon">↗</span>

--- a/src/routes/projects/devgpt/journey/+page.svelte
+++ b/src/routes/projects/devgpt/journey/+page.svelte
@@ -48,7 +48,7 @@
         'A proper context assembly system (not just dumping history into the prompt)',
         'Memory that persists across sessions — the four-layer model: Org / Team / User / Session',
         'A Kubernetes API gateway on EKS using Cilium for per-LOB auth, rate limiting, and load shedding',
-        'Hybrid model routing — Anthropic via AWS Bedrock, OpenAI via Azure OpenAI, with Bedrock inference profiles designed across 3 regions by default via Geo CRIS',
+        'Two independent services — Anthropic via AWS Bedrock, OpenAI via Azure OpenAI — with Bedrock inference profiles designed across 3 regions by default via Geo CRIS. No shared prompt router; provider selection stays a deliberate, user-facing decision rather than a platform abstraction',
         'IDE expansion: Android Studio and Xcode support on the roadmap — wanted, but never built; not enough time or headcount to take it on alongside everything else',
       ],
       bodyAfter: [
@@ -114,36 +114,36 @@
         rows: [
           ['Prompt cache hit rate', '0%', '~90%'],
           ['Live inference TPM (peak)', '~4M (and climbing)', '~6M'],
-          ['Cache read TPM (peak)', '0', '~20M'],
+          ['Cache read TPM (peak)', '0', '~32M'],
           ['TPM budget utilized', '>90% (throttled)', '~20% of 30M budget'],
           ['User-facing errors', 'Frequent', 'Eliminated'],
         ],
       },
       bodyAfter: [
-        'Cache reads on Anthropic models peak at 20 million tokens per minute. Live inference consumption drops to approximately 6 million TPM against a 30 million TPM budget. The same platform, serving more users, consuming a fraction of the quota.',
+        'Cache reads on Anthropic models peak at 32 million tokens per minute. Live inference consumption drops to approximately 6 million TPM against a 30 million TPM budget. The same platform, serving more users, consuming a fraction of the quota.',
         'Prompt caching alone brings AWS costs down 70% — the same infrastructure, serving a growing user base, at a fraction of the spend.',
         'The remaining edge cases are honest ones: inexperienced users sending requests that exceed Bedrock\'s maximum input token limits. These are operational constraints — not bugs, not architectural failures. We handle them with clear error messaging, input validation, and user education on context window limits.',
       ],
     },
     {
       date: '2025',
-      title: 'AI4Tech',
+      title: 'Platform Migration',
       tag: 'org',
-      eyebrow: 'The platform earns its own organization.',
+      eyebrow: 'A zero-downtime cutover to support firm-wide scale.',
       body: [
-        'DevGPT\'s growth — 6,500 users, firm-wide tooling impact, infrastructure that had outgrown AWM\'s shared environments — leads to a structural decision: spin out a dedicated organization.',
-        'AI4Tech is formed within AWM with its own SEAL, its own AWS accounts, and its own cost center. My manager and I move over in a two-week migration — a full AWS org cutover with a 30-minute planned maintenance window, zero data loss, no user-facing failures.',
-        'The platform now has the organizational independence to operate and scale on its own terms.',
+        'DevGPT\'s growth — 6,500 users, firm-wide tooling impact, infrastructure that had outgrown AWM\'s shared environments — forces an infrastructure decision: the platform needs its own dedicated AWS account structure to scale further.',
+        'My manager and I execute a two-week migration — a full AWS org cutover with a 30-minute planned maintenance window, zero data loss, no user-facing failures. The new team, AI4Tech, is chartered within AWM to own the platform going forward.',
+        'The migration clears the runway for the next phase: autonomous execution infrastructure.',
       ],
     },
     {
       date: 'Early 2026',
       title: 'Agentic Runtime',
       tag: 'runtime',
-      eyebrow: 'Anthropic SRT. Bubblewrap. Sub-2-second sandbox dispatch.',
+      eyebrow: 'Remote sandbox controller. Bubblewrap. Sub-2-second sandbox dispatch.',
       body: [
         'With the cost and quota problems solved, the platform can grow. And the next frontier isn\'t conversation — it\'s autonomous execution.',
-        'We architect the Anthropic Sandbox Runtime (SRT) on EKS: a pool-managed, session-aware Kubernetes pod system where agents execute untrusted code in sandboxed subprocesses using bubblewrap for kernel-level process isolation. No privileged containers. No separate runtime service.',
+        'We architect a remote sandbox controller on EKS: a pool-managed, session-aware Kubernetes pod system where agents execute untrusted code in sandboxed subprocesses using bubblewrap for kernel-level process isolation. No privileged containers. No separate runtime service.',
         'Key design decisions:',
       ],
       list: [
@@ -154,7 +154,7 @@
         'VDI-to-AWS-cloud auth flow bridges JPMC\'s on-premise VDI environment to the cloud-native runtime securely',
       ],
       bodyAfter: [
-        'The SRT turns DevGPT from a chat interface with code awareness into a platform where agents can actually run code, test it, and iterate — inside the firm\'s security boundary.',
+        'The sandbox controller turns DevGPT from a chat interface with code awareness into a platform where agents can actually run code, test it, and iterate — inside the firm\'s security boundary. It\'s deliberately decoupled from the harness: the harness reasons and issues tool calls, the sandbox controller executes them, and neither holds the other\'s credentials.',
       ],
     },
     {
@@ -177,14 +177,14 @@
       eyebrow: 'DevGPT goes firm-wide — under the hood.',
       body: [
         'The most significant expansion of DevGPT\'s scope isn\'t a new UI feature or a new model. It\'s a new use case entirely: automated software maintenance at enterprise scale.',
-        'Technology Lifecycle Management (TLM) uses DevGPT\'s agentic infrastructure to automate dependency updates, security patches, and framework migrations across JPMC\'s full technology estate — Terraform, Python, Java, and Golang codebases.',
+        'Technology Lifecycle Management (TLM) uses DevGPT\'s agentic infrastructure to automate dependency updates, security patches, and framework migrations across JPMC\'s full technology estate — Java codebases today, expanding to Python, Golang, TypeScript, and Terraform.',
         'The architecture:',
       ],
       list: [
         'Agents operate on a dedicated maintenance branch per repository',
         'A supervisor agent reviews proposed changes — diffs, test results, risk assessment — before surfacing them to the owning team',
         'Teams retain full merge authority to release/master',
-        'The system operates continuously, across the entire firm, while the platform org remains AI4Tech-chartered within AWM',
+        'The system operates continuously, across the entire firm, while the platform team remains AWM-chartered',
       ],
       callout: 'The agents propose. The humans decide. The firm moves faster.',
     },


### PR DESCRIPTION
…rop org-formation emphasis

- Reframe AI4Tech content around technical architecture (coding harness / sandbox controller brain-hands split) rather than org formation (SEAL, cost center, dedicated org)
- Rename Anthropic Sandbox Runtime (SRT) to Remote Sandbox Controller throughout
- Fix peak cache-reads/min inconsistency (20M vs 32M vs 28M) to 32M everywhere
- Remove outdated 'patent pending' claim from Sm@rt RFP
- Fix TLM scope: Java live today, expanding to Python/Golang/TypeScript/Terraform (was incorrectly stated as already covering all four)
- Fix model-integration framing: two independent mission-critical services with no shared prompt router (was 'hybrid model routing' implying a routing layer)
- Add DevGPT Cloud, AWM AI COE, and AWM Agentic Training to homepage timeline
- Add telemetry gateway pipeline detail (producer -> SQS -> consumer -> staging -> processors -> federated/Aurora + analytics/read-replica) to homepage timeline